### PR TITLE
Add ignore pattern setting to ignore files and folder to reorder

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -2,9 +2,11 @@ export interface FileOrderSettings {
   delimiter: string;
   prefixMinLength: number;
   startingIndex: number;
+  ignorePattern: string;
 }
 export const DEFAULT_SETTINGS: FileOrderSettings = {
   delimiter: " ",
   prefixMinLength: 0,
   startingIndex: 0,
+  ignorePattern: "",
 };

--- a/src/fileOrderSettingTab.ts
+++ b/src/fileOrderSettingTab.ts
@@ -90,6 +90,20 @@ export class FileOrderSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
+
+    new Setting(containerEl)
+      .setName("Ignore Pattern")
+      .setDesc(
+        "RegEx of files and folder to ignore. Eg: ^index\\.md$ to ignore index.md files"
+      )
+      .addText((text) => {
+        text
+          .setValue(this.plugin.settings.ignorePattern)
+          .onChange(async (value) => {
+            this.plugin.settings.ignorePattern = value;
+            await this.plugin.saveSettings();
+          });
+      });
   }
 
   getDelLabel() {

--- a/src/reorderDialog/reorderDialog.tsx
+++ b/src/reorderDialog/reorderDialog.tsx
@@ -19,13 +19,16 @@ export const ReorderDialog: FC<ReorderDialogProps> = ({
     useState<Array<{ item: TAbstractFile; name: string }>>(null);
   const [newFileOrder, setNewFileOrder] =
     useState<Array<{ item: TAbstractFile; name: string }>>(null);
+  const shouldInclude = (item: TAbstractFile) => {
+    return defaults.ignorePattern === "" || !item.name.match(defaults.ignorePattern);
+  }
   const originalFolders = useMemo(
-    () => sortByName(parent.children.filter((item) => item instanceof TFolder)),
+    () => sortByName(parent.children.filter((item) => item instanceof TFolder && shouldInclude(item))),
     [parent]
   );
   const originalFiles = useMemo(
     () =>
-      sortByName(parent.children.filter((item) => !(item instanceof TFolder))),
+      sortByName(parent.children.filter((item) => !(item instanceof TFolder) && shouldInclude(item))),
     [parent]
   );
 


### PR DESCRIPTION
Fixes #7
Fixes #3

@lukasbach 

The following video shows the new setting. The setting is not overridable from the modal popup.
I also show how it plays with https://github.com/LostPaul/obsidian-folder-notes if the folder note name is fixed (eg: index)

https://github.com/lukasbach/obsidian-file-order/assets/459923/7490d878-bb65-42ce-9368-930b134c642c

There is an edge case that if we ignore files in the reorder it could happen that some of the new file names might clash.
Maybe this is worth a warning or a check in the modal. I'm not sure.

