### PR TITLE
Add process polyfill for mobile compatibility

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import './process-polyfill';
 import { FileOrder } from "./fileOrder";
 
 export default FileOrder;

--- a/src/process-polyfill.ts
+++ b/src/process-polyfill.ts
@@ -1,0 +1,18 @@
+declare global {
+    interface Window {
+        process?: any;
+    }
+}
+
+// Simple process polyfill for Obsidian mobile
+window.process = {
+    env: {
+        NODE_ENV: 'production'
+    },
+    // Add any other process properties your code might need
+    platform: 'android', // or 'ios' depending on platform
+    version: '',
+    nextTick: (fn: Function) => setTimeout(fn, 0)
+};
+
+export {}; 


### PR DESCRIPTION
Fixes #10 Making it function on a mobile device 
_(at least for Android, not tested on iOS - if someone with an iOS device could let me know if it works, I'd appreciate it.)_

@lukasbach

### Problem
Plugin wasn't working on mobile - it would fail to activate with this error: 
![image](https://github.com/user-attachments/assets/8e4e3bbe-aef1-4dd8-bbaa-a2d8a8fde991)
(It WOULD work on the emulated version on desktop, which made it more confusing.)
Apparently it couldn't find the `process` object. 
Added a process polyfill to fix this.

### Changes
- Created `process-polyfill.ts` to provide the basic environment stuff React needs
- Added import for the polyfill in `main.ts`
   
### Testing
Got it working on my Android Note S9! The plugin now:
- Activates properly
- Shows up in the menu
- Lets me reorder files just like on desktop

It's finally perfect for my Android needs! (happy dance) Let me know if you need me to test anything else!