### PR TITLE
Update sort method so files starting with numbers will sort numerically

### DIFF
--- a/src/reorderDialog/utils.ts
+++ b/src/reorderDialog/utils.ts
@@ -36,7 +36,6 @@ export const obsidianCompareNames = (
 ) => {
   const aName = a instanceof TAbstractFile ? a.name : a;
   const bName = b instanceof TAbstractFile ? b.name : b;
-  //return aName.localeCompare(bName);
   var collator = new Intl.Collator([], {numeric: true});
   return collator.compare(aName, bName);
 };

--- a/src/reorderDialog/utils.ts
+++ b/src/reorderDialog/utils.ts
@@ -36,7 +36,9 @@ export const obsidianCompareNames = (
 ) => {
   const aName = a instanceof TAbstractFile ? a.name : a;
   const bName = b instanceof TAbstractFile ? b.name : b;
-  return aName.localeCompare(bName);
+  //return aName.localeCompare(bName);
+  var collator = new Intl.Collator([], {numeric: true});
+  return collator.compare(aName, bName);
 };
 
 export const sortByName = <T extends string | TAbstractFile>(items: T[]) => {


### PR DESCRIPTION
Update sort method so files starting with numbers will sort numerically before alphabetically (ex., a name that starts with 10 will be sorted after 9, not after 1).

Fixes #25 

@lukasbach 
